### PR TITLE
docs: link CI status badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Powered by Remix](https://img.shields.io/badge/powered_by-remix-black?logo=remix)](https://remix.run/)
 [![Commit activity (number of commits per month)](https://img.shields.io/github/commit-activity/m/pwbriggs/bvs?logo=github)](https://github.com/pwbriggs/bvs/commits/dev/)
 [![Time of last commit](https://img.shields.io/github/last-commit/pwbriggs/bvs/dev?logo=github)](https://github.com/pwbriggs/bvs/commits/dev/)
-![Status of CI tests on GitHub](https://img.shields.io/github/actions/workflow/status/pwbriggs/library/ci.yml?label=CI+tests&logo=github)
+[![Status of CI tests on GitHub](https://img.shields.io/github/actions/workflow/status/pwbriggs/library/ci.yml?label=CI+tests&logo=github)](https://github.com/pwbriggs/library/actions)
 
 
 Open-source software for cataloging and loaning items in a library.


### PR DESCRIPTION
Make the "CI tests" badge link to the GitHub Actions CI test workflow.