### PR TITLE
chore(deps): group Prisma's Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/client"


### PR DESCRIPTION
The `prisma` and `@prisma/client` packages match version numbers, so group them in the Dependabot config (see https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions).