### PR TITLE
refactor(database): combine patron and librarian

### DIFF
--- a/prisma/migrations/20240310045642_users/migration.sql
+++ b/prisma/migrations/20240310045642_users/migration.sql
@@ -1,0 +1,71 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `patronId` on the `Checkout` table. All the data in the column will be lost.
+  - You are about to drop the column `librarianId` on the `Log` table. All the data in the column will be lost.
+  - You are about to drop the column `patronId` on the `Log` table. All the data in the column will be lost.
+  - You are about to drop the `Librarian` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Patron` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `userId` to the `Checkout` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "LogType" ADD VALUE 'ADD_LIBRARIAN';
+ALTER TYPE "LogType" ADD VALUE 'CHANGE_LIBRARIAN';
+ALTER TYPE "LogType" ADD VALUE 'ADD_ADMIN';
+ALTER TYPE "LogType" ADD VALUE 'CHANGE_ADMIN';
+
+-- DropForeignKey
+ALTER TABLE "Checkout" DROP CONSTRAINT "Checkout_patronId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Log" DROP CONSTRAINT "Log_librarianId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Log" DROP CONSTRAINT "Log_patronId_fkey";
+
+-- AlterTable
+ALTER TABLE "Checkout" DROP COLUMN "patronId",
+ADD COLUMN     "userId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Log" DROP COLUMN "librarianId",
+DROP COLUMN "patronId",
+ADD COLUMN     "userId" INTEGER;
+
+-- DropTable
+DROP TABLE "Librarian";
+
+-- DropTable
+DROP TABLE "Patron";
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" SERIAL NOT NULL,
+    "isLibrarian" BOOLEAN NOT NULL,
+    "isAdmin" BOOLEAN NOT NULL,
+    "joined" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "loginName" TEXT NOT NULL,
+    "givenName" TEXT NOT NULL,
+    "familyName" TEXT NOT NULL,
+    "preferredName" TEXT NOT NULL,
+    "fullName" TEXT NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_loginName_key" ON "User"("loginName");
+
+-- AddForeignKey
+ALTER TABLE "Log" ADD CONSTRAINT "Log_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Checkout" ADD CONSTRAINT "Checkout_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,39 +7,31 @@ datasource db {
     url      = env("DATABASE_URL")
 }
 
-/// A patron (as distinct from a librarian)
-model Patron {
+model User {
     id            Int        @id @default(autoincrement())
+    isLibrarian   Boolean
+    isAdmin       Boolean
     joined        DateTime   @default(now())
     loginName     String     @unique
-    passwordHash  String
     givenName     String
     familyName    String /// For alphabetizing, sort by "{familyName} {givenName}"
     preferredName String /// What to call the user in casual circumstances
     fullName      String /// Not necessarily "{givenName} {familyName}" -- for advanced menus
     checkouts     Checkout[]
-    Log           Log[]
-}
-
-model Librarian {
-    id       Int    @id @default(autoincrement())
-    fullName String @unique /// Yes, this doesn't *have* to be unique, but it's less confusing.
-    activity Log[]
+    activity      Log[]
 }
 
 model Log {
-    id          Int        @id @default(autoincrement())
-    eventTime   DateTime   @default(now())
-    comment     String?
-    type        LogType
-    librarian   Librarian? @relation(fields: [librarianId], references: [id])
-    librarianId Int?
-    item        Item?      @relation(fields: [itemId], references: [id])
-    itemId      Int?
-    patron      Patron?    @relation(fields: [patronId], references: [id])
-    patronId    Int?
-    checkout    Checkout?  @relation(fields: [checkoutId], references: [id])
-    checkoutId  Int?
+    id         Int       @id @default(autoincrement())
+    eventTime  DateTime  @default(now())
+    comment    String?
+    type       LogType
+    item       Item?     @relation(fields: [itemId], references: [id])
+    itemId     Int?
+    user       User?     @relation(fields: [userId], references: [id])
+    userId     Int?
+    checkout   Checkout? @relation(fields: [checkoutId], references: [id])
+    checkoutId Int?
 }
 
 enum LogType {
@@ -51,6 +43,10 @@ enum LogType {
     CHANGE_ITEM
     ADD_PATRON
     CHANGE_PATRON
+    ADD_LIBRARIAN
+    CHANGE_LIBRARIAN
+    ADD_ADMIN
+    CHANGE_ADMIN
 }
 
 model Item {
@@ -75,8 +71,8 @@ model Checkout {
     id         Int       @id @default(autoincrement())
     item       Item      @relation(fields: [itemId], references: [id])
     itemId     Int
-    patron     Patron    @relation(fields: [patronId], references: [id])
-    patronId   Int
+    user       User      @relation(fields: [userId], references: [id])
+    userId     Int
     outTime    DateTime  @default(now())
     dueTime    DateTime
     returnTime DateTime?


### PR DESCRIPTION
Combine the Patron and Librarian models into a combined User model. This simplifies much application design. Now we don't need separate routes, separate login pages, and so on.

The combined User model doesn't have a passwordHash column, like Patron: we'll worry about passwords when authentication is implemented.

This is not a breaking change because we don't use the database in the app yet.