### PR TITLE
ci: group all dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,19 @@ updates:
       interval: "daily"
       time: "11:25" # UTC
     groups:
-      remix:
+      all:
         patterns:
-          - "@remix-run/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      prisma:
-        patterns:
-          - "prisma"
-          - "@prisma/client"
+          - "*"
+    #   remix:
+    #     patterns:
+    #       - "@remix-run/*"
+    #   react:
+    #     patterns:
+    #       - "react"
+    #       - "react-dom"
+    #       - "@types/react"
+    #       - "@types/react-dom"
+    #   prisma:
+    #     patterns:
+    #       - "prisma"
+    #       - "@prisma/client"


### PR DESCRIPTION
Make dependabot put all its dependency bumps in one PR. This is faster and simpler, and we can always go back to using smaller groups if it becomes an issue.