### PR TITLE
feat: remove construction warning header

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,7 +6,7 @@ import {
     ScrollRestoration,
 } from "@remix-run/react";
 
-import { ColorSchemeScript, MantineProvider, Box } from '@mantine/core';
+import { ColorSchemeScript, MantineProvider } from '@mantine/core';
 import '@mantine/core/styles.css';
 
 export default function App() {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -21,12 +21,6 @@ export default function App() {
             </head>
             <body style={{ margin: 0, padding: 0, overflowWrap: "break-word" }}>
                 <MantineProvider>
-                    <Box bg="yellow.2" p="sm" ta="center">
-                        <b>
-                            ⚠️ Site under construction 🏗️
-                        </b> We&apos;re still in the initial early development stage. All pages on this
-                        site are <strong>tests only.</strong>
-                    </Box>
                     <Outlet />
                 </MantineProvider>
                 <ScrollRestoration />


### PR DESCRIPTION
Get rid of the site-wide "under construction" notice. It's unhelpful.