### PR TITLE
build: decrease dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
       time: "11:25" # UTC
     groups:
       all:


### PR DESCRIPTION
Only run Dependabot once a week, instead of daily.