### PR TITLE
docs: remove old info about branches from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,3 @@
 Open-source software for cataloging and loaning items in a library.
 
 If you have feature requests or suggestions, don't hesitate to open an issue!
-
-## Git Branches
-
-The `stable` branch is always ready to deploy, with minimal bugs. In the future, the `beta` branch will be as well, but **currently `beta` is not safe for public-facing deployment** &mdash; it may give unauthenticated + unmoderated access to the database, so that we can test the code before implementing actual application logic.


### PR DESCRIPTION
Delete outdated information about our Git branches from README.md.