### PR TITLE
ci: make CI checks run on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,6 @@
 name: CI tests
 'on':
   push:
-    branches:
-      - beta
-  pull_request:
-    branches:
-      - beta
 jobs:
   playwright:
     timeout-minutes: 60

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,6 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "beta", "stable" ]
-  pull_request:
-    branches: [ "beta", "stable" ]
   schedule:
     - cron: '27 16 * * 6'
 


### PR DESCRIPTION
Don't specify a branch name for when to run check workflows.