### PR TITLE
fix: fix broken prisma import

### DIFF
--- a/app/routes/setup.tsx
+++ b/app/routes/setup.tsx
@@ -25,6 +25,7 @@ import {
     type CreateUserErrors,
     createUserFromForm,
 } from "~/scripts/create-user.server";
+import { prisma } from "~/scripts/prisma.server";
 import { checkOtp, genOtp } from "~/scripts/otp.server";
 
 enum AppSetupState {

--- a/app/routes/setup.tsx
+++ b/app/routes/setup.tsx
@@ -25,8 +25,8 @@ import {
     type CreateUserErrors,
     createUserFromForm,
 } from "~/scripts/create-user.server";
-import { prisma } from "~/scripts/prisma.server";
 import { checkOtp, genOtp } from "~/scripts/otp.server";
+import { prisma } from "~/scripts/prisma.server";
 
 enum AppSetupState {
     PendingUnlock = 0,


### PR DESCRIPTION
Import Prisma in setup.tsx. This error slipped through because prisma is a global in development for HMR-and-family reasons.