### PR TITLE
feat: add basic staff homepage and header

### DIFF
--- a/app/routes/staff._index.tsx
+++ b/app/routes/staff._index.tsx
@@ -1,0 +1,18 @@
+import { List, Text, Title } from "@mantine/core";
+import { Link } from "@remix-run/react";
+import { IconSparkles } from "@tabler/icons-react";
+
+export default function StaffHome() {
+    return (
+        <>
+            <Title>Staff Home</Title>
+            <Text>
+                Welcome, wonderful librarians! Here's some staff tools you can
+                use:
+            </Text>
+            <List icon={<IconSparkles />}>
+                <List.Item><Link to="/staff/create-user">Create new user</Link></List.Item>
+            </List>
+        </>
+    );
+}

--- a/app/routes/staff._index.tsx
+++ b/app/routes/staff._index.tsx
@@ -11,7 +11,9 @@ export default function StaffHome() {
                 use:
             </Text>
             <List icon={<IconSparkles />}>
-                <List.Item><Link to="/staff/create-user">Create new user</Link></List.Item>
+                <List.Item>
+                    <Link to="/staff/create-user">Create new user</Link>
+                </List.Item>
             </List>
         </>
     );

--- a/app/routes/staff.tsx
+++ b/app/routes/staff.tsx
@@ -1,6 +1,18 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
+import { Link, Outlet } from "@remix-run/react";
 import { auth } from "~/scripts/auth.server";
 import { trimUrl } from "~/scripts/urls.server";
+
+export default function staffHeader() {
+    return (
+        <>
+            <header style={{ backgroundColor: "green", color: "white" }}>
+                <Link to="/staff" style={{color: "white"}}>Staff home</Link>
+            </header>
+            <Outlet />
+        </>
+    );
+}
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const user = await auth.isAuthenticated(request, {

--- a/app/routes/staff.tsx
+++ b/app/routes/staff.tsx
@@ -7,7 +7,9 @@ export default function staffHeader() {
     return (
         <>
             <header style={{ backgroundColor: "green", color: "white" }}>
-                <Link to="/staff" style={{color: "white"}}>Staff home</Link>
+                <Link to="/staff" style={{ color: "white" }}>
+                    Staff home
+                </Link>
             </header>
             <Outlet />
         </>


### PR DESCRIPTION
Make a simple wrapper for `/staff/*` paths that adds a header to the page. Also write a small staff index page with links to staff tools.